### PR TITLE
Store token when pulling from cache.

### DIFF
--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionHandler.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionHandler.cs
@@ -51,8 +51,19 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
                 var claims = await _cache.GetClaimsAsync(token).ConfigureAwait(false);
                 if (claims != null)
                 {
+                    var ticket = CreateTicket(claims);
+
                     _logger.LogTrace("Token found in cache.");
-                    return AuthenticateResult.Success(CreateTicket(claims));
+
+                    if (Options.SaveToken)
+                    {
+                        ticket.Properties.StoreTokens(new[]
+                        {
+                            new AuthenticationToken {Name = "access_token", Value = token}
+                        });
+                    }
+
+                    return AuthenticateResult.Success(ticket);
                 }
 
                 _logger.LogTrace("Token is not cached.");


### PR DESCRIPTION
This is a fix  #10 . I've included the code and tests that cover the issue. 

This PR only addresses the bug, but in a future enhancement, I'd be interesting in taking this further.

* Expand the caching so that instead of directly caching claims, cache an object that contains both the claims and the items within AuthenticationProperties as properties.
* Add and wire up an "events" interface similar to how it is done with [OpenIdConnectEvents](https://github.com/aspnet/Security/blob/22d2fe99c6fd9806b36025399a217a3a8b4e50f4/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/OpenIdConnectEvents.cs) in the OIDC middleware. Among other things, this would allow for the claims/items to be manipulated prior to being added to the cache.