### PR TITLE
Allow customization of introspection requests

### DIFF
--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/IdentityModel.AspNetCore.OAuth2Introspection.csproj
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/IdentityModel.AspNetCore.OAuth2Introspection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Middleware for validating tokens using OAuth 2.0 introspection</Description>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.1.1</VersionPrefix>
     <Authors>Dominick Baier;Brock Allen</Authors>
     <TargetFrameworks>netstandard1.4;net452</TargetFrameworks>
     <AssemblyName>IdentityModel.AspNetCore.OAuth2Introspection</AssemblyName>
@@ -19,10 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.1" />
-    <PackageReference Include="IdentityModel" Version="2.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
+    <PackageReference Include="IdentityModel" Version="2.8.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/IdentityModel.AspNetCore.OAuth2Introspection.csproj
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/IdentityModel.AspNetCore.OAuth2Introspection.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
-    <PackageReference Include="IdentityModel" Version="2.8.1" />
+    <PackageReference Include="IdentityModel" Version="2.9.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/IdentityModel.AspNetCore.OAuth2Introspection.csproj
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/IdentityModel.AspNetCore.OAuth2Introspection.csproj
@@ -4,7 +4,7 @@
     <Description>ASP.NET Core Middleware for validating tokens using OAuth 2.0 introspection</Description>
     <VersionPrefix>2.1.0</VersionPrefix>
     <Authors>Dominick Baier;Brock Allen</Authors>
-    <TargetFrameworks>netstandard1.3;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;net452</TargetFrameworks>
     <AssemblyName>IdentityModel.AspNetCore.OAuth2Introspection</AssemblyName>
     <PackageId>IdentityModel.AspNetCore.OAuth2Introspection</PackageId>
     <PackageTags>OAuth2;OAuth 2.0;Introspection;Security;Identity;IdentityServer</PackageTags>
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.1" />
     <PackageReference Include="IdentityModel" Version="2.6.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionHandler.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionHandler.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) Dominick Baier & Brock Allen. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Concurrent;
-using IdentityModel.Client;
 using IdentityModel.AspNetCore.OAuth2Introspection.Infrastructure;
+using IdentityModel.AspNetCore.OAuth2Introspection.RequestHandling;
+using IdentityModel.Client;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -23,13 +23,20 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
         private readonly AsyncLazy<IntrospectionClient> _client;
         private readonly ILogger<OAuth2IntrospectionHandler> _logger;
         private readonly ConcurrentDictionary<string, AsyncLazy<IntrospectionResponse>> _lazyTokenIntrospections;
+        private readonly IIntrospectionRequestGenerator _requestGenerator;
 
-        public OAuth2IntrospectionHandler(AsyncLazy<IntrospectionClient> client, ILoggerFactory loggerFactory, IDistributedCache cache, ConcurrentDictionary<string, AsyncLazy<IntrospectionResponse>> lazyTokenIntrospections)
+        public OAuth2IntrospectionHandler(
+            AsyncLazy<IntrospectionClient> client, 
+            ILoggerFactory loggerFactory, 
+            IDistributedCache cache, 
+            ConcurrentDictionary<string, AsyncLazy<IntrospectionResponse>> lazyTokenIntrospections,
+            IIntrospectionRequestGenerator requestGenerator)
         {
             _client = client;
             _logger = loggerFactory.CreateLogger<OAuth2IntrospectionHandler>();
             _cache = cache;
             _lazyTokenIntrospections = lazyTokenIntrospections;
+            _requestGenerator = requestGenerator;
         }
 
         protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
@@ -50,7 +57,7 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
             if (Options.EnableCaching)
             {
                 var claims = await _cache.GetClaimsAsync(token).ConfigureAwait(false);
-                if (claims != null)
+                if (claims != null && await _requestGenerator.UseCacheAsync(Context.Request, claims))
                 {
                     var ticket = CreateTicket(claims);
 
@@ -67,7 +74,7 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
                     return AuthenticateResult.Success(ticket);
                 }
 
-                _logger.LogTrace("Token is not cached.");
+                _logger.LogTrace("Token is not cached, or the introspection response generator rejected the currently cached claims.");
             }
             
             // Use a LazyAsync to ensure only one thread is requesting introspection for a token - the rest will wait for the result
@@ -124,15 +131,10 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
 
         private async Task<IntrospectionResponse> LoadClaimsForToken(string token)
         {
+            var request = await _requestGenerator.GenerateRequestAsync(Context.Request, Options, token);
             var introspectionClient = await _client.Value.ConfigureAwait(false);
 
-            return await introspectionClient.SendAsync(new IntrospectionRequest
-            {
-                Token = token,
-                TokenTypeHint = OidcConstants.TokenTypes.AccessToken,
-                ClientId = Options.ClientId,
-                ClientSecret = Options.ClientSecret
-            }).ConfigureAwait(false);
+            return await introspectionClient.SendAsync(request).ConfigureAwait(false);
         }
 
         private AuthenticationTicket CreateTicket(IEnumerable<Claim> claims)

--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionMiddleware.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionMiddleware.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using IdentityModel.AspNetCore.OAuth2Introspection.Infrastructure;
-using IdentityModel.AspNetCore.OAuth2Introspection.RequestHandling;
 using IdentityModel.Client;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
@@ -25,15 +24,13 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
         private readonly IDistributedCache _cache;
         private readonly ILoggerFactory _loggerFactory;
         private readonly ConcurrentDictionary<string, AsyncLazy<IntrospectionResponse>> _lazyTokenIntrospections;
-        private readonly IIntrospectionRequestGenerator _requestGenerator;
 
         public OAuth2IntrospectionMiddleware(
-            RequestDelegate next, 
-            IOptions<OAuth2IntrospectionOptions> options, 
-            UrlEncoder urlEncoder, 
+            RequestDelegate next,
+            IOptions<OAuth2IntrospectionOptions> options,
+            UrlEncoder urlEncoder,
             ILoggerFactory loggerFactory,
-            IDistributedCache cache = null,
-            IIntrospectionRequestGenerator requestGenerator = null)
+            IDistributedCache cache = null)
             : base(next, options, loggerFactory, urlEncoder)
         {
             _loggerFactory = loggerFactory;
@@ -61,7 +58,6 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
             _cache = cache;
             _client = new AsyncLazy<IntrospectionClient>(InitializeIntrospectionClient);
             _lazyTokenIntrospections = new ConcurrentDictionary<string, AsyncLazy<IntrospectionResponse>>();
-            _requestGenerator = requestGenerator ?? new DefaultIntrospectionRequestGenerator();
         }
 
         private async Task<IntrospectionClient> InitializeIntrospectionClient()
@@ -134,7 +130,7 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
 
         protected override AuthenticationHandler<OAuth2IntrospectionOptions> CreateHandler()
         {
-            return new OAuth2IntrospectionHandler(_client, _loggerFactory, _cache, _lazyTokenIntrospections, _requestGenerator);
+            return new OAuth2IntrospectionHandler(_client, _loggerFactory, _cache, _lazyTokenIntrospections);
         }
     }
 }

--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/RequestHandling/DefaultIntrospectionRequestGenerator.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/RequestHandling/DefaultIntrospectionRequestGenerator.cs
@@ -1,0 +1,33 @@
+﻿using IdentityModel.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace IdentityModel.AspNetCore.OAuth2Introspection.RequestHandling
+{
+    public class DefaultIntrospectionRequestGenerator : IIntrospectionRequestGenerator
+    {
+        public ValueTask<IntrospectionRequest> GenerateRequestAsync(
+            HttpRequest httpRequest, 
+            OAuth2IntrospectionOptions options, 
+            string token)
+        {
+            // Default introspection request
+            return new ValueTask<IntrospectionRequest>(new IntrospectionRequest
+            {
+                Token = token,
+                TokenTypeHint = OidcConstants.TokenTypes.AccessToken,
+                ClientId = options.ClientId,
+                ClientSecret = options.ClientSecret
+            });
+        }
+
+        public ValueTask<bool> UseCacheAsync(HttpRequest httpRequest, IEnumerable<Claim> cachedClaims)
+        {
+            // Always use cached claims
+            return new ValueTask<bool>(true);
+        }
+    }
+}

--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/RequestHandling/Interfaces/IIntrospectionRequestGenerator.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/RequestHandling/Interfaces/IIntrospectionRequestGenerator.cs
@@ -1,0 +1,32 @@
+﻿using IdentityModel.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace IdentityModel.AspNetCore.OAuth2Introspection.RequestHandling
+{
+    /// <summary>
+    /// Customization point for generating introspection requests.
+    /// </summary>
+    public interface IIntrospectionRequestGenerator
+    {
+        /// <summary>
+        /// Generates an introspection request.
+        /// </summary>
+        /// <param name="httpRequest"></param>
+        /// <param name="options"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        ValueTask<IntrospectionRequest> GenerateRequestAsync(HttpRequest httpRequest, OAuth2IntrospectionOptions options, string token);
+
+        /// <summary>
+        /// Determines if the cached claims are still valid and should be used.
+        /// </summary>
+        /// <param name="httpRequest"></param>
+        /// <param name="claims"></param>
+        /// <returns></returns>
+        ValueTask<bool> UseCacheAsync(HttpRequest httpRequest, IEnumerable<Claim> cachedClaims);
+    }
+}

--- a/test/Tests/Tests.csproj
+++ b/test/Tests/Tests.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.1" />
-    <PackageReference Include="IdentityModel" Version="2.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.2" />
+    <PackageReference Include="IdentityModel" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Tests/Tests.csproj
+++ b/test/Tests/Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.2" />
-    <PackageReference Include="IdentityModel" Version="2.8.1" />
+    <PackageReference Include="IdentityModel" Version="2.9.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change adds an interface and default implementation, that allows customization of introspection requests. If a custom implementation of the interface is injected (via DI) it is used, otherwise the default request generator is used. This should be a non-breaking change.