### PR TITLE
Fix vulnerable libs

### DIFF
--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/IdentityModel.AspNetCore.OAuth2Introspection.csproj
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/IdentityModel.AspNetCore.OAuth2Introspection.csproj
@@ -4,7 +4,7 @@
     <Description>ASP.NET Core Middleware for validating tokens using OAuth 2.0 introspection</Description>
     <VersionPrefix>2.1.0</VersionPrefix>
     <Authors>Dominick Baier;Brock Allen</Authors>
-    <TargetFrameworks>netstandard1.3;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;net452</TargetFrameworks>
     <AssemblyName>IdentityModel.AspNetCore.OAuth2Introspection</AssemblyName>
     <PackageId>IdentityModel.AspNetCore.OAuth2Introspection</PackageId>
     <PackageTags>OAuth2;OAuth 2.0;Introspection;Security;Identity;IdentityServer</PackageTags>
@@ -19,10 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.1" />
-    <PackageReference Include="IdentityModel" Version="2.6.0" />
+    <PackageReference Include="IdentityModel" Version="2.8.1" />    
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/test/Tests/Tests.csproj
+++ b/test/Tests/Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.1" />
-    <PackageReference Include="IdentityModel" Version="2.6.0" />
+    <PackageReference Include="IdentityModel" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Re: https://github.com/dotnet/corefx/issues/19535

Fixes updates of the following vulnerable transient dependencies:
* Transient references of System.Text.Encodings.Web/4.3.0 

`Microsoft.AspNetCore.Authentication/1.1.1` 
=> `Microsoft.AspNetCore.Http/1.1.1` 
=> `Microsoft.AspNetCore.Http.Abstractions/1.1.1` 
=> `System.Text.Encodings.Web/4.3.0`


I had to update to re-target to netstandard1.4 due to a newer requirement in between `IdentityModel/2.6` & latest (2.8).