### PR TITLE
New options for retrieving claims

### DIFF
--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionOptions.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionOptions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Builder
         public TimeSpan UserinfoTimeout { get; set; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
-        /// Specifies the HTTP handler for the introspection endpoint
+        /// Specifies the HTTP handler for the userinfo endpoint
         /// </summary>
         public HttpMessageHandler UserinfoHttpHandler { get; set; }
 


### PR DESCRIPTION
Hi,
I forked the project and modified it adding two new features, that I'd like to see in a new release of the library.

Here is what's new:
- Added an option for retrieving claims also from the userinfo endpoint.
- Added an option for splitting the value of the role claim, for use with IPs returning multiple roles in a single claim.

About the first one, I think it's a necessary option. In my opinion, despite of its name, this library is an authentication middleware for ASP.NET Core, so it's important to give developers the ability of obtaining claims from the userinfo endpoint of the IP in addition to the ones of the introspection endpoint for authentication purpose.

About the second one: in some cases, IP servers (like WSO2 Identity Server, that a client asked to integrate with a new software) return multiples roles in a single role claim, that is not suitable for using with the ASP.NET User.IsInRole method, because this expects distinct claims for distinct roles in the Identity object.

The options are disabled by default, for backward compatibility.

About the code: The most I did is copy and modify.
I think there are some things could be done better, like the Options validation. Also, I didn't modify test projects, but I could do it, if I could have some specifications. Also, I could contribute to write docs for the new options, if accepted.

_Please, forgive me, my English could be not correct sometimes._