### PR TITLE
Proposed solution for bug #26

### DIFF
--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionHandler.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionHandler.cs
@@ -139,7 +139,7 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
 
         private async Task<IntrospectionResponse> LoadClaimsForToken(string token)
         {
-            var introspectionClient = await Options.IntrospectionClient.Value.ConfigureAwait(false);
+            var introspectionClient = Options.IntrospectionClient.Value;
 
             return await introspectionClient.SendAsync(new IntrospectionRequest
             {

--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionOptions.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionOptions.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Builder
         /// </summary>
         public Func<HttpRequest, string> TokenRetriever { get; set; } = TokenRetrieval.FromAuthorizationHeader();
 
-        internal AsyncLazy<IntrospectionClient> IntrospectionClient { get; set; }
+        internal Lazy<IntrospectionClient> IntrospectionClient { get; set; }
         internal ConcurrentDictionary<string, AsyncLazy<IntrospectionResponse>> LazyIntrospections { get; set; }
 
         /// <summary>

--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/PostConfigureOAuth2IntrospectionOptions.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/PostConfigureOAuth2IntrospectionOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 using IdentityModel.AspNetCore.OAuth2Introspection.Infrastructure;
 using IdentityModel.Client;
@@ -30,7 +31,7 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
                 throw new ArgumentException("Caching is enabled, but no IDistributedCache is found in the services collection", nameof(_cache));
             }
 
-            options.IntrospectionClient = new AsyncLazy<IntrospectionClient>(() => InitializeIntrospectionClient(options));
+            options.IntrospectionClient = new Lazy<IntrospectionClient>(() => InitializeIntrospectionClient(options).Result, LazyThreadSafetyMode.PublicationOnly);
             options.LazyIntrospections = new ConcurrentDictionary<string, AsyncLazy<IntrospectionResponse>>();
         }
 

--- a/test/Tests/Util/DiscoveryEndpointHandler.cs
+++ b/test/Tests/Util/DiscoveryEndpointHandler.cs
@@ -13,8 +13,15 @@ namespace Tests.Util
     {
         public string Endpoint { get; set; }
 
+        public bool IsFailureTest { get; set; } = false;
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
         {
+            if (IsFailureTest)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+
             if (request.RequestUri.AbsoluteUri.ToString() == "https://authority.com/.well-known/openid-configuration")
             {
                 Endpoint = request.RequestUri.AbsoluteUri;


### PR DESCRIPTION
`AsyncLazy` has no mechanism to retry on failure. It will continue to emit Values that are in an error state. Since it's possible that the Discovery endpoint can be unavailable, I proposed that `Lazy` be used rather than `AsyncLazy`.