### PR TITLE
Add OAuth2Introspection Events

### DIFF
--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionEvents.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionEvents.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace IdentityModel.AspNetCore.OAuth2Introspection
+{    
+    /// <summary>
+     /// Default implementation.
+     /// </summary>
+    public class OAuth2IntrospectionEvents
+    {
+
+        /// <summary>
+        /// Gets or sets the function that is invoked when the CreatingTicket method is invoked.
+        /// </summary>
+        public Func<ClaimsPrincipal, Task> OnCreatingTicket { get; set; } = context => Task.CompletedTask;
+
+        /// <summary>
+        /// Invoked after the provider successfully authenticates a user.
+        /// </summary>
+        /// <param name="principal">Contains claims set hydtrated from the introspection response <see cref="System.Security.Claims.ClaimsPrincipal"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the completed operation.</returns>
+        public virtual Task CreatingTicket(ClaimsPrincipal principal) => OnCreatingTicket(principal);
+    }
+}

--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionOptions.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionOptions.cs
@@ -19,6 +19,13 @@ namespace Microsoft.AspNetCore.Builder
     public class OAuth2IntrospectionOptions : AuthenticationSchemeOptions
     {
         /// <summary>
+        /// Dafault options constructor
+        /// </summary>
+        public OAuth2IntrospectionOptions()
+        {
+            Events = new OAuth2IntrospectionEvents();
+        }
+        /// <summary>
         /// Sets the base-path of the token provider.
         /// If set, the OpenID Connect discovery document will be used to find the introspection endpoint.
         /// </summary>
@@ -112,6 +119,15 @@ namespace Microsoft.AspNetCore.Builder
         /// Specifies the method how to retrieve the token from the HTTP request
         /// </summary>
         public Func<HttpRequest, string> TokenRetriever { get; set; } = TokenRetrieval.FromAuthorizationHeader();
+
+        /// <summary>
+        /// Gets or sets the <see cref="OAuth2IntrospectionEvents"/> used to handle authentication events.
+        /// </summary>
+        public new OAuth2IntrospectionEvents Events
+        {
+            get { return (OAuth2IntrospectionEvents)base.Events; }
+            set { base.Events = value; }
+        }
 
         internal AsyncLazy<IntrospectionClient> IntrospectionClient { get; set; }
         internal ConcurrentDictionary<string, AsyncLazy<IntrospectionResponse>> LazyIntrospections { get; set; }


### PR DESCRIPTION
Adding the ability to intercept the principal creation in the handler.

This mirrors the implementation on the OAuth Handler from the Microsoft.AspNetCore.Authorization package.
