### PR TITLE
CacheKeyPrefix is added

### DIFF
--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionHandler.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionHandler.cs
@@ -76,7 +76,8 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
 
             if (Options.EnableCaching)
             {
-                var claims = await _cache.GetClaimsAsync(token).ConfigureAwait(false);
+                var key = $"{Options.CacheKeyPrefix}{token}";
+                var claims = await _cache.GetClaimsAsync(key).ConfigureAwait(false);
                 if (claims != null)
                 {
                     var ticket = await CreateTicket(claims);
@@ -124,7 +125,8 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
 
                     if (Options.EnableCaching)
                     {
-                        await _cache.SetClaimsAsync(token, response.Claims, Options.CacheDuration, _logger).ConfigureAwait(false);
+                        var key = $"{Options.CacheKeyPrefix}{token}";
+                        await _cache.SetClaimsAsync(key, response.Claims, Options.CacheDuration, _logger).ConfigureAwait(false);
                     }
 
                     return AuthenticateResult.Success(ticket);

--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionOptions.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionOptions.cs
@@ -116,6 +116,11 @@ namespace Microsoft.AspNetCore.Builder
         public TimeSpan CacheDuration { get; set; } = TimeSpan.FromMinutes(5);
 
         /// <summary>
+        /// Specifies the prefix of the cache key (token).
+        /// </summary>
+        public string CacheKeyPrefix { get; set; } = string.Empty;
+
+        /// <summary>
         /// Specifies the method how to retrieve the token from the HTTP request
         /// </summary>
         public Func<HttpRequest, string> TokenRetriever { get; set; } = TokenRetrieval.FromAuthorizationHeader();


### PR DESCRIPTION
I have an issue related with a distributed caching for the outcome of introspection token with several scopes.

**STR:**
There are two services(BFFs - back for frontend), one front-end(FE) and Redis(implementation of a distributed cache).
1) FE makes a request to the service(BFF) **Foo** with scope **my_pretty_scope**
2) **Foo** service saves to cache outcome of token validation only with scope **my_pretty_scope**
3) FE makes a request to the service(BFF) **Bar** with scope **my_cool_scope**
4) **Bar** tries to take the outcome of token validation from the cache, but the scope is invalid

**Expected result:** 
Each service saves to cache token validation results with cache key with prefix

**Actual result:**
**Bar** service tries to get token with an invalid scope and FE gets 403 error

I am using IDistributedCache implementation for other requests in an application, so I cannot change implementation for the special case with caching token results.

So, I want to make that each my service put the token's outcome with service prefix.