### PR TITLE
Adding an overridable AuthenticationType to the generated identity

### DIFF
--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionHandler.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionHandler.cs
@@ -165,7 +165,8 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
 
         private async Task<AuthenticationTicket> CreateTicket(IEnumerable<Claim> claims)
         {
-            var id = new ClaimsIdentity(claims, Scheme.Name, Options.NameClaimType, Options.RoleClaimType);
+            var authenticationType = Options.AuthenticationType ?? Scheme.Name;
+            var id = new ClaimsIdentity(claims, authenticationType, Options.NameClaimType, Options.RoleClaimType);
             var principal = new ClaimsPrincipal(id);
 
             await Events.CreatingTicket(principal);

--- a/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionOptions.cs
+++ b/src/IdentityModel.AspNetCore.OAuth2Introspection/OAuth2IntrospectionOptions.cs
@@ -63,6 +63,13 @@ namespace Microsoft.AspNetCore.Builder
         public string RoleClaimType { get; set; } = "role";
 
         /// <summary>
+        /// Specifies the authentication type to use for the authenticated identity.
+        /// If not set, the authentication scheme name is used as the authentication
+        /// type (defaults to null).
+        /// </summary>
+        public string AuthenticationType { get; set; }
+
+        /// <summary>
         /// Specifies the policy for the discovery client
         /// </summary>
         public DiscoveryPolicy DiscoveryPolicy { get; set; } = new DiscoveryPolicy();


### PR DESCRIPTION
Adding "AuthenticationType" to OAuth2IntrospectionOptions that allows for overriding the generated identity's authentication type. The authentication scheme is used, by default, if not value is specified in the options.