### PR TITLE
Support modifying underlying TokenIntrospectionRequest

### DIFF
--- a/src/Context/RequestSendingContext.cs
+++ b/src/Context/RequestSendingContext.cs
@@ -1,0 +1,26 @@
+using IdentityModel.Client;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+
+namespace IdentityModel.AspNetCore.OAuth2Introspection
+{
+    /// <summary>
+    /// Context for the RequestSending event
+    /// </summary>
+    public class RequestSendingContext : BaseContext<OAuth2IntrospectionOptions>
+    {
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public RequestSendingContext(
+            HttpContext context,
+            AuthenticationScheme scheme,
+            OAuth2IntrospectionOptions options)
+            : base(context, scheme, options) { }
+
+        /// <summary>
+        /// The <see cref="TokenIntrospectionRequest"/> request
+        /// </summary>
+        public TokenIntrospectionRequest TokenIntrospectionRequest { get; set; }
+    }
+}

--- a/src/OAuth2IntrospectionEvents.cs
+++ b/src/OAuth2IntrospectionEvents.cs
@@ -27,6 +27,11 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
         public Func<UpdateClientAssertionContext, Task> OnUpdateClientAssertion { get; set; } = context => Task.CompletedTask;
 
         /// <summary>
+        /// Invoked when sending token introspection request.
+        /// </summary>
+        public Func<RequestSendingContext, Task> OnRequestSending { get; set; } = context => Task.CompletedTask;
+
+        /// <summary>
         /// Invoked if exceptions are thrown during request processing. The exceptions will be re-thrown after this event unless suppressed.
         /// </summary>
         public virtual Task AuthenticationFailed(AuthenticationFailedContext context) => OnAuthenticationFailed(context);
@@ -40,5 +45,10 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
         /// Invoked when client assertion need to be updated.
         /// </summary>
         public virtual Task UpdateClientAssertion(UpdateClientAssertionContext context) => OnUpdateClientAssertion(context);
+
+        /// <summary>
+        /// Invoked when sending token introspection request.
+        /// </summary>
+        public virtual Task RequestSending(RequestSendingContext context) => OnRequestSending(context);
     }
 }

--- a/src/OAuth2IntrospectionHandler.cs
+++ b/src/OAuth2IntrospectionHandler.cs
@@ -179,6 +179,14 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
         {
             var introspectionClient = await options.IntrospectionClient.Value.ConfigureAwait(false);
             using var request = CreateTokenIntrospectionRequest(token, context, scheme, events, options);
+
+            var requestSendingContext = new RequestSendingContext(context, scheme, options)
+            {
+                TokenIntrospectionRequest = request,
+            };
+
+            await events.RequestSending(requestSendingContext);
+
             return await introspectionClient.IntrospectTokenAsync(request).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Pull Rrequest for this issue: https://github.com/IdentityModel/IdentityModel.AspNetCore.OAuth2Introspection/issues/156

Allow users to observe and modify TokenIntrospectionRequest before sending

Use case:
Users can define additional parameters or modify "built-in" ones on per-request basis