### PR TITLE
Added event to allow parsing of extra claims from introspection result

### DIFF
--- a/src/Context/ParseAdditionalClaimsContext.cs
+++ b/src/Context/ParseAdditionalClaimsContext.cs
@@ -8,14 +8,14 @@ using System.Text.Json;
 namespace IdentityModel.AspNetCore.OAuth2Introspection
 {
     /// <summary>
-    /// Context for the ParseExtraClaims event
+    /// Context for the ParseAdditionalClaims event
     /// </summary>
-    public class ParseExtraClaimsContext : ResultContext<OAuth2IntrospectionOptions>
+    public class ParseAdditionalClaimsContext : ResultContext<OAuth2IntrospectionOptions>
     {
         /// <summary>
         /// ctor
         /// </summary>
-        public ParseExtraClaimsContext(
+        public ParseAdditionalClaimsContext(
             HttpContext context,
             AuthenticationScheme scheme,
             OAuth2IntrospectionOptions options)

--- a/src/Context/ParseExtraClaimsContext.cs
+++ b/src/Context/ParseExtraClaimsContext.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Dominick Baier & Brock Allen. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using System.Text.Json;
+
+namespace IdentityModel.AspNetCore.OAuth2Introspection
+{
+    /// <summary>
+    /// Context for the ParseExtraClaims event
+    /// </summary>
+    public class ParseExtraClaimsContext : ResultContext<OAuth2IntrospectionOptions>
+    {
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public ParseExtraClaimsContext(
+            HttpContext context,
+            AuthenticationScheme scheme,
+            OAuth2IntrospectionOptions options)
+            : base(context, scheme, options) { }
+
+        /// <summary>
+        /// The security token
+        /// </summary>
+        public JsonElement ParsedJsonResponse { get; set; }
+    }
+}

--- a/src/OAuth2IntrospectionEvents.cs
+++ b/src/OAuth2IntrospectionEvents.cs
@@ -38,7 +38,7 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
         /// <summary>
         /// Invoked before the ClaimsIdentity has been generated to allow extra claims to be extracted from the introspection response.
         /// </summary>
-        public Func<ParseExtraClaimsContext, Task<IEnumerable<Claim>>> OnParseExtraClaims { get; set; } = context => Task.FromResult(Enumerable.Empty<Claim>());
+        public Func<ParseAdditionalClaimsContext, Task<IEnumerable<Claim>>> OnParseAdditionalClaims { get; set; } = context => Task.FromResult(Enumerable.Empty<Claim>());
 
         /// <summary>
         /// Invoked if exceptions are thrown during request processing. The exceptions will be re-thrown after this event unless suppressed.
@@ -63,6 +63,6 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
         /// <summary>
         /// Invoked before the ClaimsIdentity has been generated to allow extra claims to be extracted from the introspection response.
         /// </summary>
-        public virtual Task<IEnumerable<Claim>> ParseExtraClaims(ParseExtraClaimsContext context) => OnParseExtraClaims(context);
+        public virtual Task<IEnumerable<Claim>> ParseAdditionalClaims(ParseAdditionalClaimsContext context) => OnParseAdditionalClaims(context);
     }
 }

--- a/src/OAuth2IntrospectionEvents.cs
+++ b/src/OAuth2IntrospectionEvents.cs
@@ -2,6 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace IdentityModel.AspNetCore.OAuth2Introspection
@@ -32,6 +36,11 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
         public Func<SendingRequestContext, Task> OnSendingRequest { get; set; } = context => Task.CompletedTask;
 
         /// <summary>
+        /// Invoked before the ClaimsIdentity has been generated to allow extra claims to be extracted from the introspection response.
+        /// </summary>
+        public Func<ParseExtraClaimsContext, Task<IEnumerable<Claim>>> OnParseExtraClaims { get; set; } = context => Task.FromResult(Enumerable.Empty<Claim>());
+
+        /// <summary>
         /// Invoked if exceptions are thrown during request processing. The exceptions will be re-thrown after this event unless suppressed.
         /// </summary>
         public virtual Task AuthenticationFailed(AuthenticationFailedContext context) => OnAuthenticationFailed(context);
@@ -50,5 +59,10 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
         /// Invoked when sending token introspection request.
         /// </summary>
         public virtual Task SendingRequest(SendingRequestContext context) => OnSendingRequest(context);
+
+        /// <summary>
+        /// Invoked before the ClaimsIdentity has been generated to allow extra claims to be extracted from the introspection response.
+        /// </summary>
+        public virtual Task<IEnumerable<Claim>> ParseExtraClaims(ParseExtraClaimsContext context) => OnParseExtraClaims(context);
     }
 }

--- a/src/OAuth2IntrospectionHandler.cs
+++ b/src/OAuth2IntrospectionHandler.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -15,8 +14,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using static IdentityModel.ClaimComparer;
-using static IdentityModel.OidcConstants;
 
 namespace IdentityModel.AspNetCore.OAuth2Introspection
 {
@@ -128,12 +125,12 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
 
                 if (response.IsActive)
                 {
-                    var parseExtraClaimsContext = new ParseExtraClaimsContext(Context, Scheme, Options)
+                    var parseExtraClaimsContext = new ParseAdditionalClaimsContext(Context, Scheme, Options)
                     {
                         ParsedJsonResponse = response.Json
                     };
 
-                    var extraClaims = await Events.ParseExtraClaims(parseExtraClaimsContext);
+                    var extraClaims = await Events.ParseAdditionalClaims(parseExtraClaimsContext);
                     var claims = response.Claims.Concat(extraClaims);
 
                     if (Options.EnableCaching)


### PR DESCRIPTION
Allows the user to extract extra claims from the introspection response.

Use case:
I have the case where the authentication server provides the user roles as part of the introspection response in a non-standard field. I would like to extract the roles from the introspection response and provide these roles as extra claims in the ClaimsIdentity.