### PR TITLE
Revert #173 + add unit tests

### DIFF
--- a/src/OAuth2IntrospectionHandler.cs
+++ b/src/OAuth2IntrospectionHandler.cs
@@ -187,7 +187,7 @@ namespace IdentityModel.AspNetCore.OAuth2Introspection
 
             await events.SendingRequest(requestSendingContext);
 
-            return await introspectionClient.IntrospectTokenAsync(request, context.RequestAborted).ConfigureAwait(false);
+            return await introspectionClient.IntrospectTokenAsync(request).ConfigureAwait(false);
         }
 
         private static TokenIntrospectionRequest CreateTokenIntrospectionRequest(

--- a/test/Tests/Introspection.cs
+++ b/test/Tests/Introspection.cs
@@ -107,8 +107,7 @@ namespace Tests
                 waitForTheSecondRequestToStart.Set();
                 waitForTheFirstIntrospectionToStart.WaitOne();
                 client2.SetBearerToken(token);
-                var result = await client2.GetAsync("http://test");
-                return result;
+                return await client2.GetAsync("http://test");
             });
 
             await Task.WhenAll(request1, request2);
@@ -158,8 +157,7 @@ namespace Tests
                 waitForTheSecondRequestToStart.Set();
                 waitForTheFirstIntrospectionToStart.WaitOne();
                 client2.SetBearerToken(token);
-                var result = await client2.GetAsync("http://test");
-                return result;
+                return await client2.GetAsync("http://test");
             });
 
             await Task.WhenAll(request1, request2);

--- a/test/Tests/Introspection.cs
+++ b/test/Tests/Introspection.cs
@@ -66,7 +66,7 @@ namespace Tests
         [Theory]
         [InlineData(IntrospectionEndpointHandler.Behavior.Active, HttpStatusCode.OK)]
         [InlineData(IntrospectionEndpointHandler.Behavior.Unauthorized, HttpStatusCode.Unauthorized)]
-        public async Task TwoConcurrentCalls_FirstIntrospectSucceeds_SecondShouldNotBeCalled(
+        public async Task TwoConcurrentCalls_FirstIntrospectDoesNotThrow_SecondShouldNotBeCalled(
             IntrospectionEndpointHandler.Behavior behavior,
             HttpStatusCode expectedStatusCode)
         {
@@ -112,7 +112,7 @@ namespace Tests
 
             await Task.WhenAll(request1, request2);
 
-            var result1 = await request2;
+            var result1 = await request1;
             result1.StatusCode.Should().Be(expectedStatusCode);
 
             requestCount.Should().Be(1);

--- a/test/Tests/Introspection.cs
+++ b/test/Tests/Introspection.cs
@@ -66,7 +66,7 @@ namespace Tests
         [Theory]
         [InlineData(IntrospectionEndpointHandler.Behavior.Active, HttpStatusCode.OK)]
         [InlineData(IntrospectionEndpointHandler.Behavior.Unauthorized, HttpStatusCode.Unauthorized)]
-        public async Task ActiveToken_WithTwoConcurrentCalls_FirstIntrospectSucceeds_SecondShouldNotBeCalled(
+        public async Task TwoConcurrentCalls_FirstIntrospectSucceeds_SecondShouldNotBeCalled(
             IntrospectionEndpointHandler.Behavior behavior,
             HttpStatusCode expectedStatusCode)
         {

--- a/test/Tests/Introspection.cs
+++ b/test/Tests/Introspection.cs
@@ -12,6 +12,8 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Tests.Util;
 using Xunit;
@@ -59,6 +61,111 @@ namespace Tests
             var request = handler.LastRequest;
             request.Should().ContainKey("client_id").WhichValue.Should().Be(clientId);
             request.Should().ContainKey("client_secret").WhichValue.Should().Be(clientSecret);
+        }
+
+        [Theory]
+        [InlineData(IntrospectionEndpointHandler.Behavior.Active, HttpStatusCode.OK)]
+        [InlineData(IntrospectionEndpointHandler.Behavior.Unauthorized, HttpStatusCode.Unauthorized)]
+        public async Task ActiveToken_WithTwoConcurrentCalls_FirstIntrospectSucceeds_SecondShouldNotBeCalled(
+            IntrospectionEndpointHandler.Behavior behavior,
+            HttpStatusCode expectedStatusCode)
+        {
+            const string token = "sometoken";
+            var waitForTheFirstIntrospectionToStart = new ManualResetEvent(initialState: false);
+            var waitForTheSecondRequestToStart = new ManualResetEvent(initialState: false);
+            var handler = new IntrospectionEndpointHandler(behavior);
+
+            var requestCount = 0;
+
+            var messageHandler = PipelineFactory.CreateHandler(o =>
+            {
+                _options(o);
+
+                o.Events.OnSendingRequest = async context =>
+                {
+                    requestCount += 1;
+
+                    if (requestCount == 1)
+                    {
+                        waitForTheSecondRequestToStart.WaitOne();
+                        waitForTheFirstIntrospectionToStart.Set();
+                        await Task.Delay(200); // wait for second request to reach the IntrospectionDictionary
+                    }
+                };
+            }, handler);
+
+            var client1 = new HttpClient(messageHandler);
+            var request1 = Task.Run(async () =>
+            {
+                client1.SetBearerToken(token);
+                return await client1.GetAsync("http://test");
+            });
+
+            var client2 = new HttpClient(messageHandler);
+            var request2 = Task.Run(async () =>
+            {
+                waitForTheSecondRequestToStart.Set();
+                waitForTheFirstIntrospectionToStart.WaitOne();
+                client2.SetBearerToken(token);
+                var result = await client2.GetAsync("http://test");
+                return result;
+            });
+
+            await Task.WhenAll(request1, request2);
+
+            var result1 = await request2;
+            result1.StatusCode.Should().Be(expectedStatusCode);
+
+            requestCount.Should().Be(1);
+
+            var result2 = await request2;
+            result2.StatusCode.Should().Be(expectedStatusCode);
+        }
+
+        [Fact]
+        public async Task ActiveToken_WithTwoConcurrentCalls_FirstCancelled_SecondShouldNotBeCancelled()
+        {
+            const string token = "sometoken";
+            var cts = new CancellationTokenSource();
+            var waitForTheFirstIntrospectionToStart = new ManualResetEvent(initialState: false);
+            var waitForTheSecondRequestToStart = new ManualResetEvent(initialState: false);
+            var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active);
+
+            var messageHandler = PipelineFactory.CreateHandler(o =>
+            {
+                _options(o);
+
+                o.Events.OnSendingRequest = async context =>
+                {
+                    waitForTheSecondRequestToStart.WaitOne();
+                    waitForTheFirstIntrospectionToStart.Set();
+                    cts.Cancel();
+                    await Task.Delay(200); // wait for second request to reach the IntrospectionDictionary
+                };
+            }, handler);
+
+            var client1 = new HttpClient(messageHandler);
+            var request1 = Task.Run(async () =>
+            {
+                client1.SetBearerToken(token);
+                var doRequest = () => client1.GetAsync("http://test", cts.Token);
+                await doRequest.Should().ThrowAsync<OperationCanceledException>();
+            });
+
+            var client2 = new HttpClient(messageHandler);
+            var request2 = Task.Run(async () =>
+            {
+                waitForTheSecondRequestToStart.Set();
+                waitForTheFirstIntrospectionToStart.WaitOne();
+                client2.SetBearerToken(token);
+                var result = await client2.GetAsync("http://test");
+                return result;
+            });
+
+            await Task.WhenAll(request1, request2);
+
+            var result2 = await request2;
+            result2.StatusCode.Should().Be(HttpStatusCode.OK);
         }
 
         [Theory]

--- a/test/Tests/Util/IntrospectionEndpointHandler.cs
+++ b/test/Tests/Util/IntrospectionEndpointHandler.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Tests.Util
 {
-    internal class IntrospectionEndpointHandler : DelegatingHandler
+    public class IntrospectionEndpointHandler : DelegatingHandler
     {
         private readonly Behavior _behavior;
 


### PR DESCRIPTION
Revert PR #173, which introduced bug #177.
I also added 2 unit tests: one to verify the introspection result sharing with concurrent calls. The second reproduces bug #177.

Note the cancellation test will behave differently with `IdentityModel v6.1.0` because of this [PR](https://github.com/IdentityModel/IdentityModel/pull/460). It will still fail on the second request, but because of `TaskCancelledException` instead of invalid `StatusCode`.